### PR TITLE
Revert to default bootstrap navbar dropdown behaviour

### DIFF
--- a/css/flat-ui.css
+++ b/css/flat-ui.css
@@ -518,8 +518,6 @@ h6 {
     font-weight: 700;
     padding-bottom: 16px;
     padding-top: 15px; }
-  .navbar .nav > li:hover > ul {
-    top: 100%; }
   .navbar .nav > li > ul {
     padding-top: 13px;
     top: 80%;
@@ -549,19 +547,15 @@ h6 {
     position: relative; }
     .navbar .nav li:hover > ul {
       opacity: 1;
-      z-index: 100;
-      -webkit-transform: scale(1, 1);
-      display: block\9; }
+      -webkit-transform: scale(1, 1); }
   .navbar .nav ul {
     border-radius: 4px;
     left: 15px;
     list-style-type: none;
     margin-left: 0;
-    opacity: 0;
     position: absolute;
     top: 0;
     width: 234px;
-    z-index: -100;
     -webkit-transform: scale(1, 0.99);
     -webkit-transform-origin: 0 0;
     display: none\9;

--- a/sass/modules/_navbar.sass
+++ b/sass/modules/_navbar.sass
@@ -12,9 +12,6 @@
   .nav
     // First level nav
     > li
-      &:hover
-        > ul
-          top: 100%
 
       // Second level nav
       > ul
@@ -47,10 +44,7 @@
       &:hover
         > ul
           opacity: 1
-          z-index: 100
           -webkit-transform: scale(1, 1)
-          // Show on hover
-          display: block\9
 
     // Sub menu
     ul
@@ -58,11 +52,9 @@
       left: 15px
       list-style-type: none
       margin-left: 0
-      opacity: 0
       position: absolute
       top: 0
       width: 234px
-      z-index: -100
       // Trigger transform to hide nav completely without 'ghost' bug (when switching from :hover to initial)
       -webkit-transform: scale(1, .99)
       -webkit-transform-origin: 0 0


### PR DESCRIPTION
Regarding issue #5

The dropdown appears broken as it is hidden when not hovered on but the li button keeps the open class. I've changed this display/hide behaviour to be more in keeping with the original bootstrap version.
