### PR TITLE
Filled out .palette listing based on swatches in demo

### DIFF
--- a/sass/modules/_palette.sass
+++ b/sass/modules/_palette.sass
@@ -40,11 +40,41 @@
 .palette-bright-dark
   background-color: #f39c12
 
+.palette-turquoise
+  background-color: #1ABC9C
+
+.palette-green-sea
+  background-color: #16A085
+
+.palette-emerland
+  background-color: #2ECC71
+
+.palette-nephrits
+  background-color: #27AE60
+
+.palette-peter-river
+  background-color: #3498DB
+
+.palette-belize-hole
+  background-color: #2980B9
+
 .palette-amethyst
   background-color: #9b59b6
 
 .palette-wisteria
   background-color: #8e44ad
+
+.palette-wet-asphalt
+  background-color: #34495E
+
+.palette-midnight-blue
+  background-color: #2C3E50
+
+.palette-sun-flower
+  background-color: #F1C40F
+
+.palette-orange
+  background-color: #F39C12
 
 .palette-carrot
   background-color: #e67e22


### PR DESCRIPTION
Based on the way you constructed the `.palette-clouds` (with a `background-color` declaration and a separate `color` declaration), I first just went ahead and took the same approach for all of the color swatches featured in the demo; adding the swatches from the demo that are missing in this partial. However, I realized that if done that way, the results are often too hard to read because there is not enough contrast between the `background-color` and the `color`. So I simply added the missing palette background-colors based on what's featured in the great looking demo.  
