### PR TITLE
make the link to google font css work both in http and https

### DIFF
--- a/css/flat-ui.css
+++ b/css/flat-ui.css
@@ -1,4 +1,4 @@
-@import url("http://fonts.googleapis.com/css?family=Lato:400,700,900,400italic");
+@import url("//fonts.googleapis.com/css?family=Lato:400,700,900,400italic");
 @font-face {
   font-family: "Flat-UI-Icons-16";
   src: url("../fonts/Flat-UI-Icons-16.eot");


### PR DESCRIPTION
The origin link to google font css( "http://fonts.googleapis.com/css?family=Lato:400,700,900,400italic") did not work, when you have a https site and visitor's bowser is chrome. 

chrome will automatically ignore the javascript which referenced by http link when you website is using https.

so i fixed it by removing the "http:" .
