### PR TITLE
Remove http/https handler in font face

### DIFF
--- a/css/flat-ui.css
+++ b/css/flat-ui.css
@@ -1,4 +1,4 @@
-@import url("http://fonts.googleapis.com/css?family=Lato:400,700,700italic,900,400italic,300");
+@import url("//fonts.googleapis.com/css?family=Lato:400,700,700italic,900,400italic,300");
 @font-face {
   font-family: 'Flat-UI-Icons';
   src: url('../fonts/Flat-UI-Icons.eot');

--- a/less/flat-ui.less
+++ b/less/flat-ui.less
@@ -1,7 +1,7 @@
 // Flat UI main stylesheet that aggregates all modules
 
 // Loading custom fonts
-@import url("http://fonts.googleapis.com/css?family=Lato:400,700,700italic,900,400italic,300");
+@import url("//fonts.googleapis.com/css?family=Lato:400,700,700italic,900,400italic,300");
 @import "icon-font";
 
 // Loading config with variables (changing them leads to changing a color scheme)


### PR DESCRIPTION
This fix will avoid insecure mixed content which is now automatically trash blocked by most of browser.
