### PR TITLE
Fix display regression in the TODO Search Field

### DIFF
--- a/css/flat-ui.css
+++ b/css/flat-ui.css
@@ -2968,9 +2968,6 @@ input.todo-search-field.placeholder {
   .todo li.todo-done {
     background-image: url(../images/todo/done-2x.png);
   }
-  .todo-search {
-    background-image: url(../images/todo/search-2x.png);
-  }
 }
 footer {
   background-color: #edeff1;


### PR DESCRIPTION
Currently, your GitHub Page for Flat UI shows this regression, apparently only manifesting itself on Retina displays:

![regression](https://dl.dropbox.com/s/kj928tyaeaxuznv/Screen%20Shot%202013-05-28%20at%207.29.17%20PM.png)

The reason for this seems to be that you changed that element to display an icon out of Flat-UI-Icons instead of using an image file:

``` css
.todo-search:before {
  // ...
  font-family: 'Flat-UI-Icons';
  content: "\e01c";
  // ...
}
```

The Retina Display directive, however, has remained and the display is odd. Removing this line fixes the regression.

Signed-off-by: David Celis me@davidcel.is
