### PR TITLE
Remove Checkbox Hover, Escape Less Relative Path

### DIFF
--- a/css/flat-ui.css
+++ b/css/flat-ui.css
@@ -1544,16 +1544,6 @@ fieldset[disabled] .form-control + .input-icon,
   transition: color 0.25s linear;
   -webkit-backface-visibility: hidden;
 }
-.checkbox:hover .first-icon,
-.radio:hover .first-icon {
-  opacity: 0;
-  filter: alpha(opacity=0);
-}
-.checkbox:hover .second-icon,
-.radio:hover .second-icon {
-  opacity: 1;
-  filter: alpha(opacity=100);
-}
 .checkbox.checked,
 .radio.checked {
   color: #16a085;

--- a/less/demo.less
+++ b/less/demo.less
@@ -22,7 +22,7 @@
   margin: 10px 0;
 
   .logo {
-    background: url(../images/demo/logo-mask.png) center 0 no-repeat;
+    background: ~"url(../images/demo/logo-mask.png) center 0 no-repeat";
     background-size: 236px 181px;
     height: 181px;
     margin: 0 auto 26px;
@@ -235,7 +235,7 @@
   }  
 }
 .demo-browser-author {
-  background: url(../images/demo/browser-author.jpg) center center no-repeat;
+  background: ~"url(../images/demo/browser-author.jpg) center center no-repeat";
   border: 3px solid @inverse;
   display: block;
   height: 84px;

--- a/less/modules/checkbox-and-radio.less
+++ b/less/modules/checkbox-and-radio.less
@@ -49,15 +49,8 @@
 
   // Hover State
   &:hover {
-  	color: @lightgray;
-  	.transition(color .25s linear);
-  	
-    .first-icon {
-      .opacity(0);
-    }
-    .second-icon {
-      .opacity(1);
-    }
+    color: @lightgray;
+    .transition(color .25s linear);
   }
 
   // Checked State
@@ -68,8 +61,8 @@
       .opacity(0);
     }
     .second-icon {
-    	color: @link-color;
-    	.transition(color .25s linear);
+        color: @link-color;
+        .transition(color .25s linear);
       .opacity(1);
     }
   }
@@ -96,7 +89,7 @@
         .opacity(0);
       }
       .second-icon {
-      	color: mix(@lightgray, white, 38%);
+        color: mix(@lightgray, white, 38%);
         .opacity(1);
       }
     }

--- a/less/modules/login.less
+++ b/less/modules/login.less
@@ -6,7 +6,7 @@
 @form-color: mix(@base, @inverse, 9%);
 
 .login {
-  background: url(../images/login/imac.png) 0 0 no-repeat;
+  background: ~"url(../images/login/imac.png) 0 0 no-repeat";
   background-size: 940px 778px;
   color: @inverse;
   margin-bottom: 77px;
@@ -105,7 +105,7 @@
 // Retina support
 @media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (-moz-min-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 3/2), only screen and (-o-min-device-pixel-ratio: 2/1), only screen and (-moz-min-device-pixel-ratio: 1.5), only screen and (min-device-pixel-ratio: 1.5), only screen and (min-device-pixel-ratio: 2) {
   .login {
-    background-image: url(../images/login/imac-2x.png);
+    background-image: ~"url(../images/login/imac-2x.png)";
   }  
 }    
 

--- a/less/modules/tile.less
+++ b/less/modules/tile.less
@@ -11,7 +11,7 @@
 
   &.tile-hot {
     &:before {
-      background: url(../images/tile/ribbon.png) 0 0 no-repeat;
+      background: ~"url(../images/tile/ribbon.png) 0 0 no-repeat";
       background-size: 82px 82px;
       content: '';
       height: 82px;
@@ -47,7 +47,7 @@
   .tile {
     &.tile-hot {
       &:before {
-        background-image: url(../images/tile/ribbon-2x.png);
+        background-image: ~"url(../images/tile/ribbon-2x.png)";
       }  
     }    
   }      

--- a/less/modules/todo.less
+++ b/less/modules/todo.less
@@ -15,7 +15,7 @@
     border-radius: 0 0 @border-radius-large @border-radius-large;
   }
   li {
-    background: @base url(../images/todo/todo.png) 92% center no-repeat;
+    background: @base ~"url(../images/todo/todo.png) 92% center no-repeat";
     background-size: 20px 20px;
     cursor: pointer;
     margin-top: 2px;
@@ -31,7 +31,7 @@
       padding-bottom: 20px;
     }
     &.todo-done {
-      background: transparent url(../images/todo/done.png) 92% center no-repeat;
+      background: transparent ~"url(../images/todo/done.png) 92% center no-repeat";
       background-size: 20px 20px;
       color: @firm;
 
@@ -97,10 +97,10 @@ input.todo-search-field {
 @media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (-moz-min-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 3/2), only screen and (-o-min-device-pixel-ratio: 2/1), only screen and (-moz-min-device-pixel-ratio: 1.5), only screen and (min-device-pixel-ratio: 1.5), only screen and (min-device-pixel-ratio: 2) {
   .todo {
     li {
-      background-image: url(../images/todo/todo-2x.png);
+      background-image: ~"url(../images/todo/todo-2x.png)";
       
       &.todo-done {
-        background-image: url(../images/todo/done-2x.png);
+        background-image: ~"url(../images/todo/done-2x.png)";
       }  
     }    
   }  

--- a/less/modules/video.less
+++ b/less/modules/video.less
@@ -237,7 +237,7 @@ body.vjs-full-window {
 }
 
 .vjs-mute-control {
-  background: url(../images/video/volume-full.png) center -48px no-repeat;
+  background: ~"url(../images/video/volume-full.png) center -48px no-repeat";
   background-size: 16px 64px;
   cursor: pointer !important;
   position: absolute;
@@ -255,11 +255,11 @@ body.vjs-full-window {
   &.vjs-vol-0 {
     &,
     div {
-      background-image: url(../images/video/volume-off.png);
+      background-image: ~"url(../images/video/volume-off.png)";
     }  
   }
   div {
-    background: @controls-color url(../images/video/volume-full.png) no-repeat center 2px;
+    background: @controls-color ~"url(../images/video/volume-full.png) no-repeat center 2px";
     background-size: 16px 64px;
     height: 18px;
     .transition(opacity .25s);
@@ -382,7 +382,7 @@ body.vjs-full-window {
 }
 
 .vjs-fullscreen-control {
-  background-image: url(../images/video/fullscreen.png);
+  background-image: ~"url(../images/video/fullscreen.png)";
   background-position: center -47px;
   background-size: 15px 64px;
   cursor: pointer !important;
@@ -398,7 +398,7 @@ body.vjs-full-window {
   }
   div {
     height: 18px;
-    background: url(../images/video/fullscreen.png) no-repeat center 2px;
+    background: ~"url(../images/video/fullscreen.png) no-repeat center 2px";
     background-size: 15px 64px;
     .transition(opacity .25s);
   }  


### PR DESCRIPTION
- `less/modules/checkbox-and-radio.less`:
  Remove hover state for checkbox icons for iOS usability (fixes Issue #70 (possibly) and issue #76)
  
  Change a couple tabs to 2-spaces
- **Other less changes:**
  Escape all relative paths so that lessc compiles with correct relative path
