### PR TITLE
Made small change to background colour of .first-icon and .second-icon

### DIFF
--- a/css/flat-ui.css
+++ b/css/flat-ui.css
@@ -1750,7 +1750,7 @@ fieldset[disabled] .form-control + .input-icon,
   position: absolute;
   left: 0;
   top: 0;
-  background-color: #ffffff;
+  background-color: inherit;
   margin: 0;
   opacity: 1;
   filter: alpha(opacity=100);


### PR DESCRIPTION
This is mainly relevant to radio's

Ok very, very small bug I encountered with a project I've been working on. Which involved the setting of white as the background-colour for .radio .icons .second-icon/first-icon at line 1753. Which was resulting in a white box appearing behind the radio buttons on the off-white background of a .well element. It looked a bit tacky so I set the value to inherit but transparent or the removal of the assignment of a background-color would also work.
Enjoy!
