### PR TITLE
Fix erroneous border radius on fixed/static headers

### DIFF
--- a/css/flat-ui.css
+++ b/css/flat-ui.css
@@ -897,6 +897,12 @@ fieldset[disabled] .btn-link:focus {
   border-right-width: 6px;
   border-left-width: 6px;
 }
+.navbar-static-top,
+.navbar-static-bottom,
+.navbar-fixed-top,
+.navbar-fixed-bottom {
+  border-radius: 0;
+}
 .navbar {
   font-size: 16px;
   border-radius: 6px;


### PR DESCRIPTION
Without this, you get tiny gaps at the corners of a navigation bar
