### PR TITLE
Fix erroneous border radius on fixed/static headers

### DIFF
--- a/less/modules/navbar.less
+++ b/less/modules/navbar.less
@@ -512,6 +512,7 @@
 // Fixed top/bottom
 .navbar.navbar-fixed-bottom,
 .navbar.navbar-fixed-top {
+  border-radius: 0;
   .navbar-inner {
     .navbar-form {
       .form-control {
@@ -522,6 +523,11 @@
       }
     }
   }
+}
+
+.navbar-static-top,
+.navbar-static-bottom {
+  border-radius: 0;
 }
 
 .navbar.navbar-fixed-bottom {


### PR DESCRIPTION
Without this, you get tiny gaps at the corners of a navigation bar
