### PR TITLE
Allow Flat-UI to be installed via NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "Flat-UI",
+  "version": "2.1.1",
+  "description": "Flat UI Free is made on the basis of Twitter Bootstrap in a stunning flat-style",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/designmodo/Flat-UI.git"
+  },
+  "keywords": [
+    "ui",
+    "flat",
+    "bootstrap"
+  ],
+  "author": "designmodo",
+  "license": "CC BY 3.0 and MIT",
+  "bugs": {
+    "url": "https://github.com/designmodo/Flat-UI/issues"
+  }
+}


### PR DESCRIPTION
The presence of a package.json allows the repository to be referenced and installed via NPM. Many people, myself included, prefer to reference frameworks via a package manager (and NPM is a big one) in order to streamline their project, and make installing and updating easier.
