### PR TITLE
Removed trailing comma in scale()

### DIFF
--- a/css/flat-ui.css
+++ b/css/flat-ui.css
@@ -985,9 +985,9 @@ fieldset[disabled] .btn-link:focus {
   border-bottom-style: none;
   -webkit-transition: 0.25s;
   transition: 0.25s;
-  -webkit-transform: scale(1.001, );
-  -ms-transform: scale(1.001, );
-  transform: scale(1.001, );
+  -webkit-transform: scale(1.001);
+  -ms-transform: scale(1.001);
+  transform: scale(1.001);
 }
 .dropup .caret,
 .dropup .btn-lg .caret,


### PR DESCRIPTION
Similar to https://github.com/designmodo/Flat-UI/pull/114 where there were trailing commas in scale()
