### PR TITLE
change dropdown visiblity control to match bootstrap's

### DIFF
--- a/less/modules/dropdown.less
+++ b/less/modules/dropdown.less
@@ -5,19 +5,16 @@
 .dropdown-menu {
   background-color: @dropdown-background;
   border: none;
-  display: block;
+  display: none;
   margin-top: 8px;
-  opacity: 0;
   padding: 0;
-  visibility: hidden;
   .box-shadow(none);
   .transition(.25s);
 
   // Opened state
   .open > & {
     margin-top: 18px !important;
-    opacity: 1;
-    visibility: visible;
+    display: block;
   }
   li {
     &:first-child {


### PR DESCRIPTION
Bootstrap uses `display:none` to control visibility of a dropdown, changing it to `display:block` when `open`.

Flat-UI uses `opacity:0` and `visibility:none`.

The result is the same, but when you use a 3rd party bootstrap wrapper (eg [ui-bootstrap](http://angular-ui.github.io/bootstrap/)), these differences break the dropdown in that it will be `open` but, but will still have `opacity:0` and `visibility:none`.

Changing Flat-UI to use `display:none` fixes this.
