### PR TITLE
Added support for Typeahead in TagsInput field

### DIFF
--- a/css/flat-ui.css
+++ b/css/flat-ui.css
@@ -2681,113 +2681,6 @@ fieldset[disabled] .navbar-inverse .navbar-btn.active {
   margin-top: 25.5px;
   margin-bottom: 25.5px;
 }
-.tagsinput {
-  background: white;
-  border: 2px solid #1abc9c;
-  border-radius: 6px;
-  height: 100px;
-  margin-bottom: 18px;
-  padding: 6px 1px 1px 6px;
-  overflow-y: auto;
-  text-align: left;
-}
-.tagsinput .tag {
-  border-radius: 4px;
-  background-color: #1abc9c;
-  color: #ffffff;
-  font-size: 14px;
-  cursor: pointer;
-  display: inline-block;
-  margin-right: 5px;
-  margin-bottom: 5px;
-  overflow: hidden;
-  line-height: 15px;
-  padding: 6px 13px 8px 19px;
-  position: relative;
-  vertical-align: middle;
-  -webkit-transition: 0.25s linear;
-  transition: 0.25s linear;
-}
-.tagsinput .tag:hover {
-  background-color: #16a085;
-  color: #ffffff;
-  padding-left: 12px;
-  padding-right: 20px;
-}
-.tagsinput .tag:hover .tagsinput-remove-link {
-  color: #ffffff;
-  opacity: 1;
-  display: block\9;
-}
-.tagsinput input {
-  background: transparent;
-  border: none;
-  color: #34495e;
-  font-family: "Lato", Helvetica, Arial, sans-serif;
-  font-size: 14px;
-  margin: 0px;
-  padding: 0 0 0 5px;
-  outline: none !important;
-  margin: 6px 5px 0 0;
-  vertical-align: top;
-  width: 12px;
-}
-.tagsinput-remove-link {
-  bottom: 0;
-  color: #ffffff;
-  cursor: pointer;
-  font-size: 12px;
-  opacity: 0;
-  padding: 7px 7px 5px 0;
-  position: absolute;
-  right: 0;
-  text-align: right;
-  text-decoration: none;
-  top: 0;
-  width: 100%;
-  z-index: 2;
-  display: none\9;
-}
-.tagsinput-remove-link:before {
-  color: #ffffff;
-  content: "\e00b";
-  font-family: "Flat-UI-Icons";
-}
-.tagsinput-add-container {
-  vertical-align: middle;
-  display: inline-block;
-}
-.tagsinput-add {
-  background-color: #d6dbdf;
-  border-radius: 3px;
-  color: #ffffff;
-  cursor: pointer;
-  display: inline-block;
-  font-size: 14px;
-  line-height: 1;
-  margin-bottom: 5px;
-  padding: 7px 9px;
-  vertical-align: top;
-  -webkit-transition: 0.25s linear;
-  transition: 0.25s linear;
-}
-.tagsinput-add:hover {
-  background-color: #1abc9c;
-}
-.tagsinput-add:before {
-  content: "\e009";
-  font-family: "Flat-UI-Icons";
-}
-.tags_clear {
-  clear: both;
-  width: 100%;
-  height: 0px;
-}
-.not_valid {
-  background: #fbd8db !important;
-  color: #90111a !important;
-  margin-left: 5px !important;
-}
 .twitter-typeahead {
   width: 100%;
 }
@@ -2896,6 +2789,127 @@ fieldset[disabled] .twitter-typeahead .tt-hint {
 .twitter-typeahead .tt-suggestion.tt-is-under-cursor {
   color: #fff;
   background-color: #16a085;
+}
+.tagsinput {
+  background: white;
+  border: 2px solid #1abc9c;
+  border-radius: 6px;
+  height: 100px;
+  margin-bottom: 18px;
+  padding: 6px 1px 1px 6px;
+  overflow-y: auto;
+  text-align: left;
+}
+.tagsinput .tag {
+  border-radius: 4px;
+  background-color: #1abc9c;
+  color: #ffffff;
+  font-size: 14px;
+  cursor: pointer;
+  display: inline-block;
+  margin-right: 5px;
+  margin-bottom: 5px;
+  overflow: hidden;
+  line-height: 15px;
+  padding: 6px 13px 8px 19px;
+  position: relative;
+  vertical-align: middle;
+  -webkit-transition: 0.25s linear;
+  transition: 0.25s linear;
+}
+.tagsinput .tag:hover {
+  background-color: #16a085;
+  color: #ffffff;
+  padding-left: 12px;
+  padding-right: 20px;
+}
+.tagsinput .tag:hover .tagsinput-remove-link {
+  color: #ffffff;
+  opacity: 1;
+  display: block\9;
+}
+.tagsinput input {
+  background: transparent;
+  border: none;
+  color: #34495e;
+  font-family: "Lato", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  margin: 0px;
+  padding: 0 0 0 5px;
+  outline: none !important;
+  margin: 6px 5px 0 0;
+  vertical-align: top;
+  width: 12px;
+}
+.tagsinput-remove-link {
+  bottom: 0;
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 12px;
+  opacity: 0;
+  padding: 7px 7px 5px 0;
+  position: absolute;
+  right: 0;
+  text-align: right;
+  text-decoration: none;
+  top: 0;
+  width: 100%;
+  z-index: 2;
+  display: none\9;
+}
+.tagsinput-remove-link:before {
+  color: #ffffff;
+  content: "\e00b";
+  font-family: "Flat-UI-Icons";
+}
+.tagsinput-add-container {
+  vertical-align: middle;
+  display: inline-block;
+}
+.tagsinput-add {
+  background-color: #d6dbdf;
+  border-radius: 3px;
+  color: #ffffff;
+  cursor: pointer;
+  display: inline-block;
+  font-size: 14px;
+  line-height: 1;
+  margin-bottom: 5px;
+  padding: 7px 9px;
+  vertical-align: top;
+  -webkit-transition: 0.25s linear;
+  transition: 0.25s linear;
+}
+.tagsinput-add:hover {
+  background-color: #1abc9c;
+}
+.tagsinput-add:before {
+  content: "\e009";
+  font-family: "Flat-UI-Icons";
+}
+.tags_clear {
+  clear: both;
+  width: 100%;
+  height: 0px;
+}
+.not_valid {
+  background: #fbd8db !important;
+  color: #90111a !important;
+  margin-left: 5px !important;
+}
+.tagsinput-add-container .twitter-typeahead {
+  position: static !important;
+  display: inline !important;
+}
+.tagsinput-add-container .twitter-typeahead .tt-hint {
+  display: none;
+}
+.tagsinput-add-container .twitter-typeahead .tt-query {
+  border: none;
+  font-size: 14px;
+  padding: 0 0 0 5px;
+  margin: 6px 5px 0 0;
+  height: auto;
 }
 .progress {
   background: #ebedef;

--- a/js/jquery.tagsinput.js
+++ b/js/jquery.tagsinput.js
@@ -229,6 +229,11 @@
 			
 			$(markup).insertAfter(this);
 
+			// Copy the data-* attributes from original input to the fake one
+			$.each([].filter.call(this.attributes, function(at) { return /^data-/.test(at.name); }), function(idx,attr){
+				$(data.fake_input).attr(attr.name, attr.value);
+			});
+
 			$(data.holder).css('width',settings.width);
 			$(data.holder).css('min-height',settings.height);
 			$(data.holder).css('height','100%');
@@ -252,8 +257,8 @@
 					$(event.data.fake_input).css('color','#000000');		
 				});
 						
-				if (settings.autocomplete_url != undefined) {
-					autocomplete_options = {source: settings.autocomplete_url};
+				if (settings.autocomplete_url !== undefined || settings.autocomplete !== undefined) {
+					autocomplete_options = (settings.autocomplete_url !== undefined) ? {source: settings.autocomplete_url} : {};
 					for (attrname in settings.autocomplete) { 
 						autocomplete_options[attrname] = settings.autocomplete[attrname]; 
 					}
@@ -271,6 +276,13 @@
 							$(event.data.real_input).addTag(ui.item.value,{focus:true,unique:(settings.unique)});
 							return false;
 						});
+					} else if (jQuery.fn.typeahead !== undefined) {
+						$(data.fake_input).typeahead(autocomplete_options);
+						$(data.fake_input).bind('typeahead:selected',data,function(event, datum, name){
+							$(data.fake_input).typeahead('setQuery', '');
+							$(event.data.real_input).addTag(datum.value, {focus:true,unique:(settings.unique)});
+							return false;
+               	});
 					}
 				
 					

--- a/less/flat-ui.less
+++ b/less/flat-ui.less
@@ -26,8 +26,8 @@
 @import "modules/input-groups";
 @import "modules/checkbox-and-radio";
 @import "modules/navbar";
-@import "modules/tagsinput";
 @import "modules/typeahead";
+@import "modules/tagsinput";
 @import "modules/progress-bars";
 @import "modules/slider";
 @import "modules/pager";

--- a/less/modules/tagsinput.less
+++ b/less/modules/tagsinput.less
@@ -119,3 +119,20 @@
   color: #90111a !important;
   margin-left: 5px !important;
 }
+
+.tagsinput-add-container .twitter-typeahead {
+  position: static !important;
+  display: inline !important;
+}
+
+.tagsinput-add-container .twitter-typeahead .tt-hint {
+  display: none;
+}
+
+.tagsinput-add-container .twitter-typeahead .tt-query {
+  border: none;
+  font-size: 14px;
+  padding: 0 0 0 5px;
+  margin: 6px 5px 0 0;
+  height: auto;
+}


### PR DESCRIPTION
For demo, please visit http://www.gyrocode.com/lab/flat-ui/tagsinput-typeahead.html

I am not sure whether reusing `autocomplete` option for TagsInput is a great idea. Maybe there should be a separate option for Typeahead parameters such as `typeahead`?
