### PR TITLE
Typo: "filder" -> "folder".

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -66,7 +66,7 @@
             </li>
           </ol>
           <p>
-            The easiest way to start is to use our start-up template (from <code>/dist</code> filder) where all the files are already included
+            The easiest way to start is to use our start-up template (from <code>/dist</code> folder) where all the files are already included
             and ready to use (The JS plugins are included, but not initialized. You will have to initialize them as needed).
           </p>
         </div>


### PR DESCRIPTION
A one character documentation change.
