### PR TITLE
Prefix icon font variable names to be able to use Bootstrap icons as well

### DIFF
--- a/less/modules/glyphicons.less
+++ b/less/modules/glyphicons.less
@@ -4,11 +4,11 @@
 
 @font-face {
   font-family: 'Flat-UI-Icons';
-  src: url('@{icon-font-path}@{icon-font-name}.eot');
-  src: url('@{icon-font-path}@{icon-font-name}.eot?#iefix') format('embedded-opentype'),
-       url('@{icon-font-path}@{icon-font-name}.woff') format('woff'),
-       url('@{icon-font-path}@{icon-font-name}.ttf') format('truetype'),
-       url('@{icon-font-path}@{icon-font-name}.svg#@{icon-font-svg-id}') format('svg');
+  src: url('@{fui-icon-font-path}@{fui-icon-font-name}.eot');
+  src: url('@{fui-icon-font-path}@{fui-icon-font-name}.eot?#iefix') format('embedded-opentype'),
+       url('@{fui-icon-font-path}@{fui-icon-font-name}.woff') format('woff'),
+       url('@{fui-icon-font-path}@{fui-icon-font-name}.ttf') format('truetype'),
+       url('@{fui-icon-font-path}@{fui-icon-font-name}.svg#@{fui-icon-font-svg-id}') format('svg');
 }
 
 [class^="fui-"],

--- a/less/variables.less
+++ b/less/variables.less
@@ -117,9 +117,9 @@
 //
 //## Specify custom locations of the include Glyphicons icon font.
 
-@icon-font-path:            "../fonts/glyphicons/";
-@icon-font-name:            "flat-ui-icons-regular";
-@icon-font-svg-id:          "flat-ui-icons-regular";
+@fui-icon-font-path:            "../fonts/glyphicons/";
+@fui-icon-font-name:            "flat-ui-icons-regular";
+@fui-icon-font-svg-id:          "flat-ui-icons-regular";
 
 //** Icon sizes for use in components
 @icon-normal:               16px;


### PR DESCRIPTION
Overriding Bootstrap's icon font variable makes it difficult to use both without having to make this change.
