### PR TITLE
Make .btn-link use @link-hover-decoration variable for text-decoration

### DIFF
--- a/less/modules/buttons.less
+++ b/less/modules/buttons.less
@@ -107,7 +107,7 @@
   &:hover,
   &:focus {
     color: @link-hover-color;
-    text-decoration: underline;
+    text-decoration: @link-hover-decoration;
     background-color: transparent;
   }
   &[disabled],


### PR DESCRIPTION
Without this change, `.btn-link` buttons don’t have the same `text-decoration` as links. This improves visual consistency and makes customization easier.
