### PR TITLE
Added main file in npm package.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+// You can require() this file in a CommonJS environment.
+require('./dist/js/flat-ui.js');

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Designmodo, Inc.",
   "license": "CC BY 3.0 and MIT",
   "homepage": "http://designmodo.github.io/Flat-UI/",
+  "main": "index",
   "keywords": [
     "ui",
     "flat",


### PR DESCRIPTION
Provides common js compatibility.
This way we can add:
`require('flat-ui')`
and use it with webpack, browserify, etc.

Fix #197