### PR TITLE
Fix grunt commands

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,7 +85,7 @@ module.exports = function (grunt) {
           'js/*.js',
           '!js/application.js'
         ],
-        dest: 'dist/js/<%= pkg.name %>.js'
+        dest: 'dist/js/<%= pkg.shortname %>.js'
       }
     },
 
@@ -95,7 +95,7 @@ module.exports = function (grunt) {
       },
       dist: {
         src: '<%= concat.dist.dest %>',
-        dest: 'dist/js/<%= pkg.name %>.min.js'
+        dest: 'dist/js/<%= pkg.shortname %>.min.js'
       }
     },
 
@@ -105,11 +105,11 @@ module.exports = function (grunt) {
           strictMath: true,
           sourceMap: true,
           outputSourceFiles: true,
-          sourceMapURL: '<%= pkg.name %>.css.map',
-          sourceMapFilename: 'dist/css/<%= pkg.name %>.css.map'
+          sourceMapURL: '<%= pkg.shortname %>.css.map',
+          sourceMapFilename: 'dist/css/<%= pkg.shortname %>.css.map'
         },
         files: {
-          'dist/css/<%= pkg.name %>.css': 'less/<%= pkg.name %>.less'
+          'dist/css/<%= pkg.shortname %>.css': 'less/<%= pkg.shortname %>.less'
         }
       },
       compileDocs: {
@@ -154,7 +154,7 @@ module.exports = function (grunt) {
         options: {
           map: true
         },
-        src: 'dist/css/<%= pkg.name %>.css'
+        src: 'dist/css/<%= pkg.shortname %>.css'
       },
       assets: {
         src: ['docs/assets/css/docs.css', 'docs/assets/css/demo.css']
@@ -167,7 +167,7 @@ module.exports = function (grunt) {
         'overqualified-elements': false
       },
       src: [
-        'dist/css/<%= pkg.name %>.css'
+        'dist/css/<%= pkg.shortname %>.css'
       ],
       assets: {
         options: {
@@ -185,7 +185,7 @@ module.exports = function (grunt) {
       },
       core: {
         files: {
-          'dist/css/<%= pkg.name %>.min.css': 'dist/css/<%= pkg.name %>.css'
+          'dist/css/<%= pkg.shortname %>.min.css': 'dist/css/<%= pkg.shortname %>.css'
         }
       }
     },
@@ -198,8 +198,8 @@ module.exports = function (grunt) {
         },
         files: {
           src: [
-            'dist/css/<%= pkg.name %>.css',
-            'dist/css/<%= pkg.name %>.min.css',
+            'dist/css/<%= pkg.shortname %>.css',
+            'dist/css/<%= pkg.shortname %>.min.css',
             'docs/assets/css/docs.css',
             'docs/assets/css/demo.css'
           ]
@@ -213,7 +213,7 @@ module.exports = function (grunt) {
       },
       dist: {
         files: {
-          'dist/css/<%= pkg.name %>.css': 'dist/css/<%= pkg.name %>.css'
+          'dist/css/<%= pkg.shortname %>.css': 'dist/css/<%= pkg.shortname %>.css'
         }
       },
       assets: {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "designmodo-flat-ui",
+  "shortname": "flat-ui",
   "version": "2.3.0",
   "description": "Flat UI Free is a beautiful theme for Bootstrap. We have redesigned many of its components to look flat in every pixel",
   "author": "Designmodo, Inc.",


### PR DESCRIPTION
This change is needed 'cause I changed the package name from "flat-ui" to "designmodo-flat-ui". :sunglasses: 

We don't know who hold the "flat-ui" package in npm registry... so after a long list of emails without reply, we create another one. :disappointed: 